### PR TITLE
split freeze and fix some small bugs

### DIFF
--- a/model.py
+++ b/model.py
@@ -42,14 +42,21 @@ class Net(nn.Module):
         x = self.qfc(x)
         return x
 
+    def reuse_qparam(self):
+        # 重用qparam
+        self.qrelu1.set_qparam(qi=self.qconv1.qo)
+        self.qconv2.set_qparam(qi=self.qconv1.qo)
+        self.qrelu2.set_qparam(qi=self.qconv2.qo)
+        self.qfc.set_qparam(qi=self.qconv2.qo)
+
     def freeze(self):
         self.qconv1.freeze()
-        self.qrelu1.freeze(self.qconv1.qo)
-        self.qmaxpool2d_1.freeze(self.qconv1.qo)
-        self.qconv2.freeze(qi=self.qconv1.qo)
-        self.qrelu2.freeze(self.qconv2.qo)
-        self.qmaxpool2d_2.freeze(self.qconv2.qo)
-        self.qfc.freeze(qi=self.qconv2.qo)
+        self.qrelu1.freeze()
+        self.qmaxpool2d_1.freeze()
+        self.qconv2.freeze()
+        self.qrelu2.freeze()
+        self.qmaxpool2d_2.freeze()
+        self.qfc.freeze()
 
     def quantize_inference(self, x):
         qx = self.qconv1.qi.quantize_tensor(x)
@@ -104,12 +111,17 @@ class NetBN(nn.Module):
         x = self.qfc(x)
         return x
 
+    def reuse_qparam(self):
+        # 重用qparam
+        self.qconv2.set_qparam(qi=self.qconv1.qo)
+        self.qfc.set_qparam(qi=self.qconv2.qo)
+
     def freeze(self):
         self.qconv1.freeze()
-        self.qmaxpool2d_1.freeze(self.qconv1.qo)
-        self.qconv2.freeze(qi=self.qconv1.qo)
-        self.qmaxpool2d_2.freeze(self.qconv2.qo)
-        self.qfc.freeze(qi=self.qconv2.qo)
+        self.qmaxpool2d_1.freeze()
+        self.qconv2.freeze()
+        self.qmaxpool2d_2.freeze()
+        self.qfc.freeze()
 
     def quantize_inference(self, x):
         qx = self.qconv1.qi.quantize_tensor(x)

--- a/post_training_quantize.py
+++ b/post_training_quantize.py
@@ -39,7 +39,11 @@ def quantize_inference(model, test_loader):
 if __name__ == "__main__":
     batch_size = 64
     using_bn = True
-    load_quant_model_file = None
+    if using_bn:
+        load_quant_model_file = "ckpt/mnist_cnnbn_ptq.pt"
+    else:
+        load_quant_model_file = "ckpt/mnist_cnn_ptq.pt"
+    # load_quant_model_file = None
     # load_model_file = None
 
     train_loader = torch.utils.data.DataLoader(
@@ -78,14 +82,14 @@ if __name__ == "__main__":
 
 
     if load_quant_model_file is not None:
+        model.reuse_qparam()
         model.load_state_dict(torch.load(load_quant_model_file))
         print("Successfully load quantized model %s" % load_quant_model_file)
-    
-
-    direct_quantize(model, train_loader)
-
-    torch.save(model.state_dict(), save_file)
-    model.freeze()
+    else:
+        direct_quantize(model, train_loader)
+        model.reuse_qparam()
+        model.freeze()
+        torch.save(model.state_dict(), save_file)
 
     # 测试是否设备转移是否正确
     # model.cuda()


### PR DESCRIPTION
1. 将`freeze()`拆成`reuse_qparam()`和`freeze()`，前者复用`qparam`，后者负责提前计算。这样做的优点是每次推理的时候免除了`freeze()`部分的计算（例如`M`），缺点是部分`qparam`被重复保存。
2. 统一`buffer`被保存的`shape`为`torch.Size([])`，避免`M`读取时的类型冲突。
3. 添加了一些操作，非常粗糙地模拟32位定点数乘法。
4. 修复了`QReLU`和`QMaxPooling2d`会多存一个`qo`的bug。